### PR TITLE
Add Steps for Interaction Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,48 @@ Run the following command:
 $ npm run test-screener
 ```
 
+### Testing Interactions
+
+To test interactions, you can add `Steps` to each state to interact with the UI. This is useful for clicking buttons, filling out forms, and getting the UI into the proper visual state to test.
+
+Here is an example:
+
+```
+var Steps = require('screener-runner').Steps;
+
+module.exports = {
+  ...
+
+  states: [
+    {
+      url: 'http://some-url.com',
+      name: 'Name of UI State',
+      steps: new Steps()
+        .click('.btn-demo')
+        .snapshot('Open Dialog')
+        .end()
+    }
+  ]
+};
+```
+
+Screener-Runner provides a fluent API for adding steps. Methods with selectors have built-in waits to simplify test flow creation.
+
+The following methods are currently available:
+
+- `click(selector)`: this will click on the first element matching the provided css selector.
+- `snapshot(name)`: this will capture a Screener snapshot.
+- `hover(selector)`: this will move the mouse over the first element matching the provided css selector.
+- `setValue(selector, value)`: this will set the value of the input field matching the provided css selector.
+- `executeScript(code)`: this executes custom JS code against the client browser the test is running in.
+- `ignore(selector)`: this ignores all elements matching the provided css selector(s).
+- `wait(ms)`: this will pause execution for the specified number of ms.
+- `wait(selector)`: this will wait until the element matching the provided css selector is present.
+- `end()`: this will return the steps to be run.
+
+**Note:** When adding `Steps` using the fluent API, you **must** end the method chain with `end()`.
+
+
 ### Additional Configuration Options
 
 **Note:** Screener will automatically set `build` and `branch` options if you are using one of the following CI tools: Jenkins, CircleCI, Travis CI, Codeship, Drone, Bitbucket Pipelines, Semaphore.

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,5 +1,5 @@
 var api = require('./api');
-var validate = require('./validate');
+var Validate = require('./validate');
 var Rules = require('./rules');
 var Tunnel = require('./tunnel');
 var CI = require('./ci');
@@ -20,7 +20,7 @@ var transformToTunnelHost = function(states, host, tunnelHost) {
 exports.run = function(config) {
   // create copy of config
   config = cloneDeep(config);
-  return validate.runnerConfig(config)
+  return Validate.runnerConfig(config)
     .then(function() {
       // apply includeRules and excludeRules
       config.states = Rules.filter(config.states, 'name', config.includeRules, config.excludeRules);

--- a/src/runner.js
+++ b/src/runner.js
@@ -17,6 +17,8 @@ var transformToTunnelHost = function(states, host, tunnelHost) {
   });
 };
 
+exports.Steps = require('./steps');
+
 exports.run = function(config) {
   // create copy of config
   config = cloneDeep(config);

--- a/src/runner.js
+++ b/src/runner.js
@@ -17,6 +17,17 @@ var transformToTunnelHost = function(states, host, tunnelHost) {
   });
 };
 
+var getTotalStates = exports.getTotalStates = function(states) {
+  var total = 0;
+  states.forEach(function(state) {
+    total++;
+    (state.steps || []).forEach(function(step) {
+      if (step.type.indexOf('Screenshot') > 0) total++;
+    });
+  });
+  return total;
+};
+
 exports.Steps = require('./steps');
 
 exports.run = function(config) {
@@ -49,7 +60,8 @@ exports.run = function(config) {
       }
     })
     .then(function(tunnelHost) {
-      console.log(config.states.length + ' UI state' + (config.states.length === 1 ? '' : 's') + ' to capture and test');
+      var totalStates = getTotalStates(config.states);
+      console.log(totalStates + ' UI state' + (totalStates === 1 ? '' : 's') + ' to capture and test');
       console.log('Creating build for ' + config.projectRepo);
       if (tunnelHost) {
         config.states = transformToTunnelHost(config.states, config.tunnel.host, tunnelHost);

--- a/src/steps.js
+++ b/src/steps.js
@@ -1,0 +1,106 @@
+var Validate = require('./validate');
+
+function Steps() {
+  this.steps = [];
+}
+
+Steps.prototype.snapshot = function(name) {
+  var step = {
+    type: 'saveScreenshot',
+    name: name
+  };
+  this.steps.push(step);
+  return this;
+};
+
+Steps.prototype.click = function(selector) {
+  var step = {
+    type: 'clickElement',
+    locator: {
+      type: 'css selector',
+      value: selector
+    }
+  };
+  this.steps.push(step);
+  return this;
+};
+
+Steps.prototype.hover = function(selector) {
+  var step = {
+    type: 'moveTo',
+    locator: {
+      type: 'css selector',
+      value: selector
+    }
+  };
+  this.steps.push(step);
+  return this;
+};
+
+Steps.prototype.setValue = function(selector, text) {
+  var step = {
+    type: 'setElementText',
+    locator: {
+      type: 'css selector',
+      value: selector
+    },
+    text: text
+  };
+  this.steps.push(step);
+  return this;
+};
+
+// isAsync requires a "done()" method to be called
+Steps.prototype.executeScript = function(code, isAsync) {
+  var step = {
+    type: 'executeScript',
+    code: code
+  };
+  if (isAsync === true) {
+    step.isAsync = true;
+  }
+  this.steps.push(step);
+  return this;
+};
+
+Steps.prototype.ignore = function(selector) {
+  var step = {
+    type: 'ignoreElements',
+    locator: {
+      type: 'css selector',
+      value: selector
+    }
+  };
+  this.steps.push(step);
+  return this;
+};
+
+Steps.prototype.wait = function(msOrSelector) {
+  var step;
+  if (typeof msOrSelector === 'number') {
+    step = {
+      type: 'pause',
+      waitTime: msOrSelector
+    };
+  } else {
+    step = {
+      type: 'waitForElementPresent',
+      locator: {
+        type: 'css selector',
+        value: msOrSelector
+      }
+    };
+  }
+  this.steps.push(step);
+  return this;
+};
+
+Steps.prototype.end = function() {
+  var result = Validate.steps(this.steps);
+  if (result.error) {
+    throw result.error;
+  }
+  return this.steps;
+};
+
+module.exports = Steps;

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,73 +1,76 @@
 var Joi = require('joi');
 var Promise = require('bluebird');
 
-exports.runnerConfig = function(value) {
-  var schema = Joi.object().keys({
-    apiKey: Joi.string().required(),
-    projectRepo: Joi.string().max(100).required(),
-    build: Joi.string().max(40),
-    branch: Joi.string().max(100),
-    resolution: Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
-    ignore: Joi.string(),
-    includeRules: Joi.array().min(0).items(
-      Joi.string(),
-      Joi.object().type(RegExp)
-    ),
-    excludeRules: Joi.array().min(0).items(
-      Joi.string(),
-      Joi.object().type(RegExp)
-    ),
-    states: Joi.array().min(0).items(
-      Joi.object().keys({
-        url: Joi.string().uri().required(),
-        name: Joi.string().max(100).required()
-      })
-    ).required(),
-    tunnel: Joi.object().keys({
-      host: Joi.string().required(),
-      gzip: Joi.boolean()
-    }),
-    diffOptions: Joi.object().keys({
-      structure: Joi.boolean(),
-      layout: Joi.boolean(),
-      style: Joi.boolean(),
-      content: Joi.boolean()
+var stepsSchema = Joi.array().min(0).items(
+  Joi.object().keys({
+    type: Joi.string().valid('saveScreenshot').required(),
+    name: Joi.string().required()
+  }),
+  Joi.object().keys({
+    type: Joi.string().valid(['clickElement', 'moveTo', 'ignoreElements', 'waitForElementPresent']).required(),
+    locator: Joi.object().keys({
+      type: Joi.string().valid('css selector').required(),
+      value: Joi.string().required()
     })
-  }).required();
+  }),
+  Joi.object().keys({
+    type: Joi.string().valid('setElementText').required(),
+    locator: Joi.object().keys({
+      type: Joi.string().valid('css selector').required(),
+      value: Joi.string().required()
+    }),
+    text: Joi.string().required()
+  }),
+  Joi.object().keys({
+    type: Joi.string().valid('executeScript').required(),
+    code: Joi.string().required(),
+    isAsync: Joi.boolean()
+  }),
+  Joi.object().keys({
+    type: Joi.string().valid('pause').required(),
+    waitTime: Joi.number().required()
+  })
+);
+
+var runnerSchema = Joi.object().keys({
+  apiKey: Joi.string().required(),
+  projectRepo: Joi.string().max(100).required(),
+  build: Joi.string().max(40),
+  branch: Joi.string().max(100),
+  resolution: Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
+  ignore: Joi.string(),
+  includeRules: Joi.array().min(0).items(
+    Joi.string(),
+    Joi.object().type(RegExp)
+  ),
+  excludeRules: Joi.array().min(0).items(
+    Joi.string(),
+    Joi.object().type(RegExp)
+  ),
+  states: Joi.array().min(0).items(
+    Joi.object().keys({
+      url: Joi.string().uri().required(),
+      name: Joi.string().max(100).required(),
+      steps: stepsSchema
+    })
+  ).required(),
+  tunnel: Joi.object().keys({
+    host: Joi.string().required(),
+    gzip: Joi.boolean()
+  }),
+  diffOptions: Joi.object().keys({
+    structure: Joi.boolean(),
+    layout: Joi.boolean(),
+    style: Joi.boolean(),
+    content: Joi.boolean()
+  })
+}).required();
+
+exports.runnerConfig = function(value) {
   var validator = Promise.promisify(Joi.validate);
-  return validator(value, schema);
+  return validator(value, runnerSchema);
 };
 
 exports.steps = function(value) {
-  var schema = Joi.array().min(0).items(
-    Joi.object().keys({
-      type: Joi.string().valid('saveScreenshot').required(),
-      name: Joi.string().required()
-    }),
-    Joi.object().keys({
-      type: Joi.string().valid(['clickElement', 'moveTo', 'ignoreElements', 'waitForElementPresent']).required(),
-      locator: Joi.object().keys({
-        type: Joi.string().valid('css selector').required(),
-        value: Joi.string().required()
-      })
-    }),
-    Joi.object().keys({
-      type: Joi.string().valid('setElementText').required(),
-      locator: Joi.object().keys({
-        type: Joi.string().valid('css selector').required(),
-        value: Joi.string().required()
-      }),
-      text: Joi.string().required()
-    }),
-    Joi.object().keys({
-      type: Joi.string().valid('executeScript').required(),
-      code: Joi.string().required(),
-      isAsync: Joi.boolean()
-    }),
-    Joi.object().keys({
-      type: Joi.string().valid('pause').required(),
-      waitTime: Joi.number().required()
-    })
-  ).required();
-  return Joi.validate(value, schema);
+  return Joi.validate(value, stepsSchema);
 };

--- a/src/validate.js
+++ b/src/validate.js
@@ -37,3 +37,37 @@ exports.runnerConfig = function(value) {
   var validator = Promise.promisify(Joi.validate);
   return validator(value, schema);
 };
+
+exports.steps = function(value) {
+  var schema = Joi.array().min(0).items(
+    Joi.object().keys({
+      type: Joi.string().valid('saveScreenshot').required(),
+      name: Joi.string().required()
+    }),
+    Joi.object().keys({
+      type: Joi.string().valid(['clickElement', 'moveTo', 'ignoreElements', 'waitForElementPresent']).required(),
+      locator: Joi.object().keys({
+        type: Joi.string().valid('css selector').required(),
+        value: Joi.string().required()
+      })
+    }),
+    Joi.object().keys({
+      type: Joi.string().valid('setElementText').required(),
+      locator: Joi.object().keys({
+        type: Joi.string().valid('css selector').required(),
+        value: Joi.string().required()
+      }),
+      text: Joi.string().required()
+    }),
+    Joi.object().keys({
+      type: Joi.string().valid('executeScript').required(),
+      code: Joi.string().required(),
+      isAsync: Joi.boolean()
+    }),
+    Joi.object().keys({
+      type: Joi.string().valid('pause').required(),
+      waitTime: Joi.number().required()
+    })
+  ).required();
+  return Joi.validate(value, schema);
+};

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,7 +1,7 @@
 var Joi = require('joi');
 var Promise = require('bluebird');
 
-var stepsSchema = Joi.array().min(0).items(
+var stepsSchema = exports.stepsSchema = Joi.array().min(0).items(
   Joi.object().keys({
     type: Joi.string().valid('saveScreenshot').required(),
     name: Joi.string().required()

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -137,4 +137,23 @@ describe('screener-runner/src/runner', function() {
         });
     });
   });
+
+  describe('Runner.getTotalStates', function() {
+    it('should return count of all states', function() {
+      var states = [{}, {}, {}];
+      expect(Runner.getTotalStates(states)).to.equal(3);
+    });
+
+    it('should return count including steps', function() {
+      var states = [{
+        steps: [
+          {type: 'clickElement'},
+          {type: 'saveScreenshot'},
+          {type: 'setElementText'},
+          {type: 'saveScreenshot'}
+        ]
+      }];
+      expect(Runner.getTotalStates(states)).to.equal(3);
+    });
+  });
 });

--- a/test/steps.spec.js
+++ b/test/steps.spec.js
@@ -1,0 +1,215 @@
+var expect = require('chai').expect;
+var Steps = require('../src/steps');
+
+describe('screener-runner/src/steps', function() {
+  describe('new Steps()', function() {
+    it('should initialize steps array', function() {
+      var test = new Steps();
+      expect(test.steps).to.deep.equal([]);
+    });
+  });
+
+  describe('Steps.prototype.snapshot', function() {
+    it('should add snapshot step', function() {
+      var test = new Steps().snapshot('name');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'saveScreenshot',
+          name: 'name'
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.click', function() {
+    it('should add click step', function() {
+      var test = new Steps().click('selector');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'clickElement',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.hover', function() {
+    it('should add hover step', function() {
+      var test = new Steps().hover('selector');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'moveTo',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.setValue', function() {
+    it('should add setValue step', function() {
+      var test = new Steps().setValue('selector', 'text');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'setElementText',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          },
+          text: 'text'
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.executeScript', function() {
+    it('should add executeScript step', function() {
+      var test = new Steps().executeScript('code');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'executeScript',
+          code: 'code'
+        }
+      ]);
+    });
+
+    it('should add async executeScript step', function() {
+      var test = new Steps().executeScript('code', true);
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'executeScript',
+          code: 'code',
+          isAsync: true
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.ignore', function() {
+    it('should add ignore step', function() {
+      var test = new Steps().ignore('selector');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'ignoreElements',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.wait', function() {
+    it('should add pause step', function() {
+      var test = new Steps().wait(300);
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'pause',
+          waitTime: 300
+        }
+      ]);
+    });
+
+    it('should add wait for element step', function() {
+      var test = new Steps().wait('selector');
+      expect(test.steps).to.deep.equal([
+        {
+          type: 'waitForElementPresent',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        }
+      ]);
+    });
+  });
+
+  describe('Steps.prototype.end', function() {
+    it('should throw error if invalid step added', function() {
+      var test = new Steps();
+      test.steps.push({});
+      try {
+        test.end();
+        throw new Error('should not be here');
+      } catch(ex) {
+        expect(ex.message).to.equal('"value" at position 0 does not match any of the allowed types');
+      }
+    });
+
+    it('should return steps', function() {
+      var result = new Steps()
+        .snapshot('State Name')
+        .click('selector')
+        .hover('selector')
+        .setValue('selector', 'text')
+        .executeScript('code')
+        .executeScript('code', true)
+        .ignore('selector')
+        .wait(300)
+        .wait('msOrSelector')
+        .end();
+      expect(result).to.deep.equal([
+        {
+          type: 'saveScreenshot',
+          name: 'State Name'
+        },
+        {
+          type: 'clickElement',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        },
+        {
+          type: 'moveTo',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        },
+        {
+          type: 'setElementText',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          },
+          text: 'text'
+        },
+        {
+          type: 'executeScript',
+          code: 'code'
+        },
+        {
+          type: 'executeScript',
+          code: 'code',
+          isAsync: true
+        },
+        {
+          type: 'ignoreElements',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        },
+        {
+          type: 'pause',
+          waitTime: 300
+        },
+        {
+          type: 'waitForElementPresent',
+          locator: {
+            type: 'css selector',
+            value: 'msOrSelector'
+          }
+        }
+      ]);
+    });
+  });
+
+});

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -1,6 +1,62 @@
 var expect = require('chai').expect;
 var Validate = require('../src/validate');
 
+var steps = [
+  {
+    type: 'saveScreenshot',
+    name: 'State Name'
+  },
+  {
+    type: 'clickElement',
+    locator: {
+      type: 'css selector',
+      value: 'selector'
+    }
+  },
+  {
+    type: 'moveTo',
+    locator: {
+      type: 'css selector',
+      value: 'selector'
+    }
+  },
+  {
+    type: 'setElementText',
+    locator: {
+      type: 'css selector',
+      value: 'selector'
+    },
+    text: 'text'
+  },
+  {
+    type: 'executeScript',
+    code: 'code'
+  },
+  {
+    type: 'executeScript',
+    code: 'code',
+    isAsync: true
+  },
+  {
+    type: 'ignoreElements',
+    locator: {
+      type: 'css selector',
+      value: 'selector'
+    }
+  },
+  {
+    type: 'pause',
+    waitTime: 300
+  },
+  {
+    type: 'waitForElementPresent',
+    locator: {
+      type: 'css selector',
+      value: 'msOrSelector'
+    }
+  }
+];
+
 describe('screener-runner/src/validate', function() {
   describe('validate.runnerConfig', function() {
     it('should throw error when no value passed in', function() {
@@ -42,6 +98,13 @@ describe('screener-runner/src/validate', function() {
       return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{}]})
         .catch(function(err) {
           expect(err.message).to.equal('child "states" fails because ["states" at position 0 fails because [child "url" fails because ["url" is required]]]');
+        });
+    });
+
+    it('should allow states with steps', function() {
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name', steps: steps}, {url: 'http://url.com', name: 'name'}]})
+        .catch(function() {
+          throw new Error('Should not be here');
         });
     });
 
@@ -113,73 +176,18 @@ describe('screener-runner/src/validate', function() {
     });
 
     it('should error when valid step with extra property is added', function() {
-      var steps = [
+      var testSteps = [
         {
           type: 'saveScreenshot',
           name: 'hello',
           extra: 'prop'
         }
       ];
-      var result = Validate.steps(steps);
+      var result = Validate.steps(testSteps);
       expect(result.error.message).to.equal('"value" at position 0 does not match any of the allowed types');
     });
 
     it('should allow all valid types', function() {
-      var steps = [
-        {
-          type: 'saveScreenshot',
-          name: 'State Name'
-        },
-        {
-          type: 'clickElement',
-          locator: {
-            type: 'css selector',
-            value: 'selector'
-          }
-        },
-        {
-          type: 'moveTo',
-          locator: {
-            type: 'css selector',
-            value: 'selector'
-          }
-        },
-        {
-          type: 'setElementText',
-          locator: {
-            type: 'css selector',
-            value: 'selector'
-          },
-          text: 'text'
-        },
-        {
-          type: 'executeScript',
-          code: 'code'
-        },
-        {
-          type: 'executeScript',
-          code: 'code',
-          isAsync: true
-        },
-        {
-          type: 'ignoreElements',
-          locator: {
-            type: 'css selector',
-            value: 'selector'
-          }
-        },
-        {
-          type: 'pause',
-          waitTime: 300
-        },
-        {
-          type: 'waitForElementPresent',
-          locator: {
-            type: 'css selector',
-            value: 'msOrSelector'
-          }
-        }
-      ];
       var result = Validate.steps(steps);
       expect(result.error).to.equal(null);
     });

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -96,9 +96,9 @@ describe('screener-runner/src/validate', function() {
   });
 
   describe('validate.steps', function() {
-    it('should error when no value passed in', function() {
-      var result = Validate.steps(undefined);
-      expect(result.error.message).to.equal('"value" is required');
+    it('should error when value not array', function() {
+      var result = Validate.steps('test');
+      expect(result.error.message).to.equal('"value" must be an array');
     });
 
     it('should error when step with invalid type added', function() {

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -1,97 +1,187 @@
 var expect = require('chai').expect;
-var validate = require('../src/validate');
+var Validate = require('../src/validate');
 
 describe('screener-runner/src/validate', function() {
   describe('validate.runnerConfig', function() {
     it('should throw error when no value passed in', function() {
-      return validate.runnerConfig()
+      return Validate.runnerConfig()
         .catch(function(err) {
           expect(err.message).to.equal('"value" is required');
         });
     });
 
     it('should throw error when no apiKey', function() {
-      return validate.runnerConfig({})
+      return Validate.runnerConfig({})
         .catch(function(err) {
           expect(err.message).to.equal('child "apiKey" fails because ["apiKey" is required]');
         });
     });
 
     it('should throw error when no projectRepo', function() {
-      return validate.runnerConfig({apiKey: 'key'})
+      return Validate.runnerConfig({apiKey: 'key'})
         .catch(function(err) {
           expect(err.message).to.equal('child "projectRepo" fails because ["projectRepo" is required]');
         });
     });
 
     it('should throw error when no states', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo'})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo'})
         .catch(function(err) {
           expect(err.message).to.equal('child "states" fails because ["states" is required]');
         });
     });
 
     it('should allow states with no values', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: []})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: []})
         .catch(function() {
           throw new Error('Should not be here');
         });
     });
 
     it('should throw error when states item is incorrect shape', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{}]})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{}]})
         .catch(function(err) {
           expect(err.message).to.equal('child "states" fails because ["states" at position 0 fails because [child "url" fails because ["url" is required]]]');
         });
     });
 
     it('should throw error when tunnel exists but host is not set', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], tunnel: {}})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], tunnel: {}})
         .catch(function(err) {
           expect(err.message).to.equal('child "tunnel" fails because [child "host" fails because ["host" is required]]');
         });
     });
 
     it('should allow adding optional fields', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], tunnel: {host: 'host'}, build: 'build', branch: 'branch', resolution: '1280x1024', ignore: 'ignore', includeRules: [], excludeRules: [], diffOptions: {}})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], tunnel: {host: 'host'}, build: 'build', branch: 'branch', resolution: '1280x1024', ignore: 'ignore', includeRules: [], excludeRules: [], diffOptions: {}})
         .catch(function() {
           throw new Error('Should not be here');
         });
     });
 
     it('should allow include/exclude rules that are strings', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], includeRules: ['string'], excludeRules: ['string']})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], includeRules: ['string'], excludeRules: ['string']})
         .catch(function() {
           throw new Error('Should not be here');
         });
     });
 
     it('should allow include/exclude rules that are regex expressions', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], includeRules: [/^string$/], excludeRules: [/^string$/]})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], includeRules: [/^string$/], excludeRules: [/^string$/]})
         .catch(function() {
           throw new Error('Should not be here');
         });
     });
 
     it('should throw error when include/exclude rules are not in array', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], includeRules: 'string', excludeRules: 'string'})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], includeRules: 'string', excludeRules: 'string'})
         .catch(function(err) {
           expect(err.message).to.equal('child "includeRules" fails because ["includeRules" must be an array]');
         });
     });
 
     it('should throw error when resolution in incorrect format', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: 'resolution'})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: 'resolution'})
         .catch(function(err) {
           expect(err.message).to.equal('child "resolution" fails because ["resolution" with value "resolution" fails to match the resolution pattern]');
         });
     });
 
     it('should throw error when field is unknown', function() {
-      return validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], someKey: 'key'})
+      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], someKey: 'key'})
         .catch(function(err) {
           expect(err.message).to.equal('"someKey" is not allowed');
         });
+    });
+  });
+
+  describe('validate.steps', function() {
+    it('should error when no value passed in', function() {
+      var result = Validate.steps(undefined);
+      expect(result.error.message).to.equal('"value" is required');
+    });
+
+    it('should error when step with invalid type added', function() {
+      var steps = [
+        {
+          type: 'type',
+          name: 'hello'
+        }
+      ];
+      var result = Validate.steps(steps);
+      expect(result.error.message).to.equal('"value" at position 0 does not match any of the allowed types');
+    });
+
+    it('should error when valid step with extra property is added', function() {
+      var steps = [
+        {
+          type: 'saveScreenshot',
+          name: 'hello',
+          extra: 'prop'
+        }
+      ];
+      var result = Validate.steps(steps);
+      expect(result.error.message).to.equal('"value" at position 0 does not match any of the allowed types');
+    });
+
+    it('should allow all valid types', function() {
+      var steps = [
+        {
+          type: 'saveScreenshot',
+          name: 'State Name'
+        },
+        {
+          type: 'clickElement',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        },
+        {
+          type: 'moveTo',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        },
+        {
+          type: 'setElementText',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          },
+          text: 'text'
+        },
+        {
+          type: 'executeScript',
+          code: 'code'
+        },
+        {
+          type: 'executeScript',
+          code: 'code',
+          isAsync: true
+        },
+        {
+          type: 'ignoreElements',
+          locator: {
+            type: 'css selector',
+            value: 'selector'
+          }
+        },
+        {
+          type: 'pause',
+          waitTime: 300
+        },
+        {
+          type: 'waitForElementPresent',
+          locator: {
+            type: 'css selector',
+            value: 'msOrSelector'
+          }
+        }
+      ];
+      var result = Validate.steps(steps);
+      expect(result.error).to.equal(null);
     });
   });
 });


### PR DESCRIPTION
## Changes

- Update config validation to support `steps`
- Create Steps class with fluent API
- Expose `stepsSchema` in `Validate`
- Create `getTotalStates` method that also counts snapshots in steps
- Update Unit Tests
- Update README docs with fluent API methods and example

## How to Test

```
$ npm test
```
