### PR TITLE
Add device emulation options to resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ The following methods are currently available:
 - **build:** Build number from your CI tool. Screener will auto-generate a Build number if not provided.
 - **branch:** Current branch name for your repo
 - **resolution:** Screen resolution to use. Defaults to `1024x768`
+    - Accepts a string in the format: `<width>x<height>`. Example: `1024x768`
+    - Or accepts an object for Device Emulation. Example:
+    ```javascript
+    {
+      deviceName: 'iPhone 6'
+    }
+    ```
+    - deviceName value can be one of: iPhone 4, iPhone 5, iPhone 6, iPhone 6 Plus, iPad, iPad Pro, Galaxy S5, Nexus 4, Nexus 5, Nexus 5X, Nexus 6P, Nexus 7, Nexus 10
+    - deviceOrientation option also available. Can be `portrait` or `landscape`. Defaults to `portrait`.
 - **ignore:** Comma-delimited string of CSS Selectors that represent areas to be ignored. Example: `.qa-ignore-date, .qa-ignore-ad`
 - **includeRules:** Optional array of strings or RegExp expressions to filter states by. Rules are matched against state name. All matching states will be kept.
     - Example:

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,6 +1,19 @@
 var Joi = require('joi');
 var Promise = require('bluebird');
 
+var resolutionSchema = exports.resolutionSchema = Joi.alternatives().try(
+  Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
+  Joi.object().keys({
+    width: Joi.number().min(320).max(1920).required(),
+    height: Joi.number().min(320).max(1920).required(),
+    userAgent: Joi.string()
+  }),
+  Joi.object().keys({
+    deviceName: Joi.string().required(),
+    deviceOrientation: Joi.string().valid('portrait', 'landscape')
+  })
+);
+
 var stepsSchema = exports.stepsSchema = Joi.array().min(0).items(
   Joi.object().keys({
     type: Joi.string().valid('saveScreenshot').required(),
@@ -37,7 +50,7 @@ var runnerSchema = Joi.object().keys({
   projectRepo: Joi.string().max(100).required(),
   build: Joi.string().max(40),
   branch: Joi.string().max(100),
-  resolution: Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
+  resolution: resolutionSchema,
   ignore: Joi.string(),
   includeRules: Joi.array().min(0).items(
     Joi.string(),

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -143,18 +143,62 @@ describe('screener-runner/src/validate', function() {
         });
     });
 
-    it('should throw error when resolution in incorrect format', function() {
-      return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: 'resolution'})
-        .catch(function(err) {
-          expect(err.message).to.equal('child "resolution" fails because ["resolution" with value "resolution" fails to match the resolution pattern]');
-        });
-    });
-
     it('should throw error when field is unknown', function() {
       return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], someKey: 'key'})
         .catch(function(err) {
           expect(err.message).to.equal('"someKey" is not allowed');
         });
+    });
+
+    describe('validate.resolutionSchema', function() {
+      it('should throw error when resolution in incorrect format', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: 'resolution'})
+          .catch(function(err) {
+            expect(err.message).to.equal('child "resolution" fails because ["resolution" with value "resolution" fails to match the resolution pattern, "resolution" must be an object, "resolution" must be an object]');
+          });
+      });
+
+      it('should allow resolution in string format <width>x<height>', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: '1024x768'})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should allow resolution in device object format', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: {deviceName: 'iPhone 6'}})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should allow resolution in device object format with orientation', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: {deviceName: 'iPhone 6', deviceOrientation: 'landscape'}})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should allow resolution in object format', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: {width: 1024, height: 768}})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should allow resolution in object format with user agent string', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: {width: 1024, height: 768, userAgent: 'user agent string'}})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should throw error when resolution object in incorrect format', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [{url: 'http://url.com', name: 'name'}], resolution: {deviceName: 'iPhone 6', width: 1024, height: 768}})
+          .catch(function(err) {
+            expect(err.message).to.equal('child "resolution" fails because ["resolution" must be a string, "deviceName" is not allowed, "width" is not allowed, "height" is not allowed]');
+          });
+      });
     });
   });
 


### PR DESCRIPTION
## Changes

- create `resolutionSchema` validation to support deviceName/deviceOrientation object:
    ```javascript
    {
      deviceName: 'iPhone 6',
      deviceOrientation: 'landscape'
    }
    ```
- Update Unit Tests
- Update README docs with new resolution options

## How to Test

```
$ npm test
```
