### PR TITLE
Improve Proxy server performance with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ $ npm install --save-dev screener-runner
 Then add a script to your `package.json`:
 ```javascript
 "scripts": {
-  "test-screener": "screener-runner --conf screener.conf.js"
+  "test-screener": "screener-runner --conf screener.config.js"
 }
 ```
 
 Then add a configuration file to your project root. Here is an example:
 
-**screener.conf.js**
+**screener.config.js**
 ```javascript
 module.exports = {
   // full repository name for your project:
@@ -162,6 +162,14 @@ module.exports = {
     ```javascript
     tunnel: {
       host: 'localhost:3000'
+    }
+    ```
+    - `gzip` and `cache` options are also available to improve tunnel performance. Example:
+    ```javascript
+    tunnel: {
+      host: 'localhost:3000',
+      gzip: true, // gzip compress all content being served from tunnel host
+      cache: true // sets cache-control header for all content being served from tunnel host. Must be used with gzip option
     }
     ```
 - **diffOptions:** Visual diff options to control validations.

--- a/src/gzip-proxy.js
+++ b/src/gzip-proxy.js
@@ -4,20 +4,70 @@ var httpProxy = require('http-proxy');
 var compression = require('compression');
 var portfinder = require('portfinder');
 var Promise = require('bluebird');
+var request = require('request');
+var Cache = {};
 
-var startGzipProxyServer = function(targetHost, callback) {
+var startGzipProxyServer = function(options, callback) {
   var app = connect();
 
   var proxy = httpProxy.createProxyServer({
-    target: 'http://' + targetHost
+    target: 'http://' + options.targetHost
   });
 
   // gzip/deflate outgoing responses
   app.use(compression());
 
-  // proxy all requests
+  app.use(function(req, res, next) {
+    if (options.cache) {
+      // monkey-patch res.writeHead with cache-control header
+      res.oldWriteHead = res.writeHead;
+      res.writeHead = function(statusCode, headers) {
+        res.setHeader('cache-control', 'public, max-age=900');
+        res.oldWriteHead(statusCode, headers);
+      };
+    }
+    next();
+  });
+
+  // handle requests
+  app.use(function(req, res, next) {
+    if (!options.cache) {
+      return next();
+    }
+    var cached = Cache[req.url];
+    if (cached) {
+      // serve from cache
+      res.writeHead(200, cached.headers);
+      res.write(cached.body);
+      res.end();
+    } else if (req.method === 'GET' && req.url.indexOf('/') === 0 && /\.js$/.test(req.url)) {
+      // cache all JS requests in-memory
+      request.get('http://' + options.targetHost + req.url, function(err, response, body) {
+        // fallback to proxy request on error
+        if (err) return next();
+        var headers = {
+          'content-type': 'application/javascript'
+        };
+        Cache[req.url] = {
+          headers: headers,
+          body: body
+        };
+        res.writeHead(200, headers);
+        res.write(body);
+        res.end();
+      });
+    } else next();
+  });
+
   app.use(function(req, res) {
+    // proxy requests
     proxy.web(req, res);
+  });
+
+  // ensure proxied requests have connection set to keep-alive
+  // to fix closed connection issues resulting in 502 Bad Gateway errors
+  proxy.on('proxyReq', function(proxyReq) {
+    proxyReq.setHeader('connection', 'keep-alive');
   });
 
   // find free port
@@ -33,7 +83,7 @@ var startGzipProxyServer = function(targetHost, callback) {
   });
 };
 
-exports.startServer = function(targetHost) {
+exports.startServer = function(options) {
   var startServer = Promise.promisify(startGzipProxyServer);
-  return startServer(targetHost);
+  return startServer(options);
 };

--- a/src/runner.js
+++ b/src/runner.js
@@ -52,7 +52,11 @@ exports.run = function(config) {
     })
     .then(function() {
       if (config.tunnel && config.tunnel.gzip) {
-        return GzipProxy.startServer(config.tunnel.host);
+        var options = {
+          targetHost: config.tunnel.host,
+          cache: config.tunnel.cache
+        };
+        return GzipProxy.startServer(options);
       } else {
         return Promise.resolve();
       }

--- a/src/validate.js
+++ b/src/validate.js
@@ -72,7 +72,8 @@ var runnerSchema = Joi.object().keys({
   ).required(),
   tunnel: Joi.object().keys({
     host: Joi.string().required(),
-    gzip: Joi.boolean()
+    gzip: Joi.boolean(),
+    cache: Joi.boolean()
   }),
   diffOptions: Joi.object().keys({
     structure: Joi.boolean(),


### PR DESCRIPTION
## Changes

- Option to cache all proxied `.js` files requested in-memory, to reduce requests to tunnelled server
- Option to set cache-control header on all proxied requests, to reduce requests through tunnel
- Fix to ensure proxied requests always have connection header set to `keep-alive`
- Update README docs with `gzip` and `cache` tunnel options

## How to Test

```
$ npm test
```
