### PR TITLE
Add failureExitCode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ module.exports = {
       content: true
     }
     ```
+- **failureExitCode:** The exit code to use on failure. Defaults to 1, which will fail a CI build.
+    - To NOT fail a CI build on Screener failure, set to 0. Example:
+    ```javascript
+    failureExitCode: 0
+    ```
 - **browsers:** Optional array of browsers for Cross Browser Testing. Each item in array is an object with `browserName` and `version` properties.
     - Note: `browsers` is dependent on `sauce` being added to configuration.
     - `browserName` and `version` *must* match one of the supported browsers/versions in the browser table below.

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,5 +35,9 @@ Runner.run(config)
     console.error('---');
     console.error('Exiting Screener Runner');
     console.error('Need help? Contact: support@screener.io');
-    process.exit(1);
+    var exitCode = 1;
+    if (config && typeof config.failureExitCode === 'number') {
+      exitCode = config.failureExitCode;
+    }
+    process.exit(exitCode);
   });

--- a/src/runner.js
+++ b/src/runner.js
@@ -95,7 +95,7 @@ exports.run = function(config) {
       if (tunnelHost) {
         config.states = transformToTunnelHost(config.states, config.tunnel.host, tunnelHost);
       }
-      var payload = omit(config, ['apiKey', 'resolution', 'resolutions', 'includeRules', 'excludeRules', 'tunnel']);
+      var payload = omit(config, ['apiKey', 'resolution', 'resolutions', 'includeRules', 'excludeRules', 'tunnel', 'failureExitCode']);
       console.log('\n' + totalStates + ' UI state' + (totalStates === 1 ? '' : 's') + ' to capture per ' + (config.browsers ? 'browser/' : '') + 'resolution');
       if (config.browsers) {
         console.log('Browsers:');

--- a/src/validate.js
+++ b/src/validate.js
@@ -99,7 +99,8 @@ var runnerSchema = Joi.object().keys({
     style: Joi.boolean(),
     content: Joi.boolean()
   }),
-  sauce: sauceSchema
+  sauce: sauceSchema,
+  failureExitCode: Joi.number().integer().min(0).max(255).default(1)
 }).without('resolutions', ['resolution']).with('browsers', ['sauce']).required();
 
 exports.runnerConfig = function(value) {

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -150,6 +150,22 @@ describe('screener-runner/src/validate', function() {
         });
     });
 
+    describe('validate.failureExitCode', function() {
+      it('should allow setting to 0', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], failureExitCode: 0})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should error when setting above 255', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], failureExitCode: 256})
+          .catch(function(err) {
+            expect(err.message).to.equal('child "failureExitCode" fails because ["failureExitCode" must be less than or equal to 255]');
+          });
+      });
+    });
+
     describe('validate.browsers', function() {
       it('should error when browsers is empty', function() {
         return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: []})


### PR DESCRIPTION
## Changes

- Add new `failureExitCode` config option
- Add validation rules for new `failureExitCode` option
- Update unit tests
- Update README

## How to Test

```
$ npm test
```
