### PR TITLE
Use Ngrok Fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "http-proxy": "~1.16.2",
     "joi": "~9.2.0",
     "lodash": "~4.16.6",
-    "ngrok": "~2.2.3",
+    "ngrok": "screener-io/ngrok",
     "portfinder": "~1.0.10",
     "request": "~2.78.0",
     "request-promise": "~4.1.1"

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -10,8 +10,7 @@ exports.connect = function(host, token) {
   var options = {
     addr: urlObj.hostname + ':' + (urlObj.port || 80),
     host_header: urlObj.hostname,
-    authtoken: token,
-    configPath: __dirname + '/ngrok.yml'
+    authtoken: token
   };
   var connect = Promise.promisify(ngrok.connect);
   return connect(options)

--- a/test/tunnel.spec.js
+++ b/test/tunnel.spec.js
@@ -15,7 +15,6 @@ describe('screener-runner/src/tunnel', function() {
     it('should pass host/token and return tunnel url on success', function() {
       Tunnel.__set__('ngrok', {
         connect: function(options, cb) {
-          delete options.configPath;
           expect(options).to.deep.equal({
             addr: 'localhost:8080',
             host_header: 'localhost',
@@ -33,7 +32,6 @@ describe('screener-runner/src/tunnel', function() {
     it('should default to port 80 if port not set', function() {
       Tunnel.__set__('ngrok', {
         connect: function(options, cb) {
-          delete options.configPath;
           expect(options).to.deep.equal({
             addr: 'localhost:80',
             host_header: 'localhost',


### PR DESCRIPTION
## Changes

- Use `screener-io` forked version of Ngrok package, which sets `-authtoken` param on start
- Remove `configPath` from tunnel
- Update unit tests

## How to Test

```
$ npm test
```
