### PR TITLE
Add Support for Screener Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,67 @@ module.exports = {
 ```
 
 
+### Cross Browser Testing
+
+**Overview**
+
+For Cross Browser Testing, Screener provides access to Chrome and Firefox browsers and device emulation out-of-the-box. To test against additional browsers, Screener integrates with [Sauce Labs](https://saucelabs.com/) to provide access to IE, Safari and Edge browsers. By default, Screener runs tests against the Chrome browser, which does **not** require a Sauce account.
+
+To test against multiple browsers, add the `browsers` option to your `screener.config.js` file.
+
+To test IE, Safari or Edge browsers, a Sauce Labs account is required, and your Sauce credentials need to be added via the `sauce` option in your `screener.config.js` file. Browsers added *must* match one of the supported browsers/versions in the browser table below.
+
+Here is a CircleCI example that only runs cross browser tests when committing into `master` branch:
+
+```javascript
+var config = {
+  // regular screener config
+};
+
+// only run cross browser tests when merging into ‘master’ branch
+if (process.env.CIRCLE_BRANCH === 'master') {
+  config.browsers = [
+    {
+      browserName: 'chrome'
+    },
+    {
+      browserName: 'firefox'
+    },
+    {
+      browserName: 'internet explorer',
+      version: '11.103'
+    }
+  ];
+  config.sauce = {
+    username: 'sauce_user',
+    accessKey: 'sauce_access_key',
+    maxConcurrent: 10
+  };
+}
+
+module.exports = config;
+```
+
+**Supported Browsers**
+
+| browserName  | version | |
+| ------------- | ------------- | ------------- |
+| chrome | *-do not set-* | |
+| firefox | *-do not set-* | |
+| internet explorer | 11.103 | _requires Sauce Account_ |
+| microsoftedge | 16.16299 | _requires Sauce Account_ |
+| safari | 11.0 | _requires Sauce Account_ |
+
+
+**Important Notes about Cross Browser Testing with Sauce Labs:**
+
+- Cross Browser Testing with Sauce Labs will be slower than regular Screener visual regression tests, and so it is not recommended to run on every commit.
+- You may want to limit cross browser testing to certain scenarios, such as only when merging into master (see example above).
+- Requirements: A valid Sauce Labs account, and access to enough concurrency in your Sauce account to run Screener tests. Each browser/resolution combination will use one concurrent machine.
+- Screener's auto-parallelization is disabled when using Sauce Labs browsers to reduce the number of concurrent browsers required in your Sauce account, unless `sauce.maxConcurrent` is set.
+
+
+
 ### Additional Configuration Options
 
 **Note:** Screener will automatically set `build`, `branch`, and `commit` options if you are using one of the following CI tools: Jenkins, CircleCI, Travis CI, Visual Studio Team Services, Codeship, GitLab CI, Drone, Bitbucket Pipelines, Semaphore, Buildkite.
@@ -153,7 +214,6 @@ module.exports = {
 - **baseBranch:** Optional branch name of your project's base branch (e.g. master). Set this option when developing using feature branches to:
     - automatically compare and accept changes when merging a feature branch into the base branch, or when rebasing a feature branch.
     - automatically pull the initial baseline of UI states for a feature branch from this base branch.
-- **initialBaselineBranch:** Optional branch name you would like to pull the initial baseline of UI states from (e.g. master).
 - **includeRules:** Optional array of strings or RegExp expressions to filter states by. Rules are matched against state name. All matching states will be kept.
     - Example:
     ```javascript
@@ -203,14 +263,16 @@ module.exports = {
     failureExitCode: 0
     ```
 - **browsers:** Optional array of browsers for Cross Browser Testing. Each item in array is an object with `browserName` and `version` properties.
-    - Note: `browsers` is dependent on `sauce` being added to configuration.
-    - `browserName` and `version` *must* match one of the supported browsers/versions in the browser table below.
+    - `browserName` and `version` *must* match one of the supported browsers/versions in the browser table above.
 	- Example:
 	```javascript
     browsers: [
       {
+        browserName: 'chrome'
+      },
+      {
         browserName: 'safari',
-        version: '10.0'
+        version: '11.0'
       }
     ]
     ```
@@ -230,58 +292,3 @@ module.exports = {
       instance: 'myproject.visualstudio.com'
     }
     ```
-
-### Sauce Labs Integration for Cross Browser Testing
-
-**Important Notes about Cross Browser Testing:**
-
-- Cross Browser Testing with Sauce Labs will be slower than regular Screener visual regression tests, and so it is not recommended to run on every commit.
-- You may want to limit cross browser testing to certain scenarios, such as only when merging into master (see example below).
-- Requirements: A valid Sauce Labs account, and access to enough concurrency in your Sauce account to run Screener tests. Each browser/resolution combination will use one concurrent machine.
-- Screener's auto-parallelization is disabled when Cross Browser Testing to reduce the number of concurrent browsers required in your Sauce account.
-
-**Overview**
-
-For cross browser testing, Screener integrates with [Sauce Labs](https://saucelabs.com/) to provide access to additional browsers. By default, Screener runs tests against the Chrome browser, which does **not** require a Sauce account. Screener provides Chrome browsers and device emulation out-of-the-box.
-
-To test against multiple browsers, add the `browsers` and `sauce` properties to your screener configuration file. Browsers added *must* match one of the supported browsers/versions in the browser table below.
-
-Here is a CircleCI example that only runs cross browser tests when committing into `master` branch:
-
-```javascript
-var config = {
-  // regular screener config
-};
-
-// only run cross browser tests when merging into ‘master’ branch
-if (process.env.CIRCLE_BRANCH === 'master') {
-  config.browsers = [
-    {
-      browserName: 'chrome'
-    },
-    {
-      browserName: 'internet explorer',
-      version: '11.103'
-    }
-  ];
-  config.sauce = {
-    username: 'sauce_user',
-    accessKey: 'sauce_access_key',
-    maxConcurrent: 10
-  };
-}
-
-module.exports = config;
-```
-
-**Supported Browsers**
-
-| browserName  | version |
-| ------------- | ------------- |
-| chrome | *-do not set-* |
-| firefox | 55.0 |
-| firefox | 54.0 |
-| firefox | 53.0 |
-| internet explorer | 11.103 |
-| microsoftedge | 15.15063 |
-| safari | 11.0 |

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -10,6 +10,7 @@ exports.connect = function(host, token) {
   var options = {
     addr: urlObj.hostname + ':' + (urlObj.port || 80),
     host_header: urlObj.hostname,
+    bind_tls: true,
     authtoken: token
   };
   var connect = Promise.promisify(ngrok.connect);

--- a/src/validate.js
+++ b/src/validate.js
@@ -16,7 +16,7 @@ var resolutionSchema = exports.resolutionSchema = Joi.alternatives().try(
 
 var browsersSchema = exports.browsersSchema = Joi.array().min(1).unique().items(
   Joi.object().keys({
-    browserName: Joi.string().valid(['chrome']).required()
+    browserName: Joi.string().valid(['chrome', 'firefox']).required()
   }),
   Joi.object().keys({
     browserName: Joi.string().valid(['firefox', 'safari', 'microsoftedge', 'internet explorer']).required(),
@@ -123,7 +123,7 @@ var runnerSchema = Joi.object().keys({
   meta: Joi.object(),
   failureExitCode: Joi.number().integer().min(0).max(255).default(1),
   beforeEachScript: [Joi.func(), Joi.string()]
-}).without('resolutions', ['resolution']).with('browsers', ['sauce']).required();
+}).without('resolutions', ['resolution']).required();
 
 exports.runnerConfig = function(value) {
   var validator = Promise.promisify(Joi.validate);

--- a/test/runner.spec.js
+++ b/test/runner.spec.js
@@ -128,8 +128,8 @@ describe('screener-runner/src/runner', function() {
           expect(payload).to.deep.equal({
             projectRepo: 'repo',
             browsers: [
-              { browserName: 'chrome' },
-              { browserName: 'firefox', version: '53.0' }
+              { browserName: 'firefox' },
+              { browserName: 'safari', version: '11.0' }
             ],
             resolutions: [
               '1024x768',
@@ -153,8 +153,8 @@ describe('screener-runner/src/runner', function() {
       });
       var tmpConfig = JSON.parse(JSON.stringify(config));
       tmpConfig.browsers = [
-        { browserName: 'chrome' },
-        { browserName: 'firefox', version: '53.0' }
+        { browserName: 'firefox' },
+        { browserName: 'safari', version: '11.0' }
       ];
       tmpConfig.sauce = sauceCreds;
       tmpConfig.pullRequest = '1';

--- a/test/tunnel.spec.js
+++ b/test/tunnel.spec.js
@@ -18,7 +18,8 @@ describe('screener-runner/src/tunnel', function() {
           expect(options).to.deep.equal({
             addr: 'localhost:8080',
             host_header: 'localhost',
-            authtoken: 'token'
+            authtoken: 'token',
+            bind_tls: true
           });
           cb(null, 'https://tunnel-url');
         }
@@ -35,7 +36,8 @@ describe('screener-runner/src/tunnel', function() {
           expect(options).to.deep.equal({
             addr: 'localhost:80',
             host_header: 'localhost',
-            authtoken: 'token'
+            authtoken: 'token',
+            bind_tls: true
           });
           cb(null, 'https://tunnel-url');
         }

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -204,13 +204,6 @@ describe('screener-runner/src/validate', function() {
           });
       });
 
-      it('should error when browsers is set without sauce', function() {
-        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }]})
-          .catch(function(err) {
-            expect(err.message).to.equal('"browsers" missing required peer "sauce"');
-          });
-      });
-
       it('should error when browsers are not unique', function() {
         return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }, { browserName: 'chrome' }], sauce: { username: 'user', accessKey: 'key' }})
           .catch(function(err) {
@@ -218,22 +211,36 @@ describe('screener-runner/src/validate', function() {
           });
       });
 
+      it('should allow screener browsers with no version', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }, { browserName: 'firefox' }]})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should allow firefox browser with or without version to be backward compatible', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'firefox', version: '57.0' }]})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
       it('should allow browsers with sauce config', function() {
-        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'firefox', version: '53.0' }], sauce: { username: 'user', accessKey: 'key' }})
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11.0' }], sauce: { username: 'user', accessKey: 'key' }})
           .catch(function() {
             throw new Error('Should not be here');
           });
       });
 
       it('should allow with sauce.maxConcurrent', function() {
-        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'firefox', version: '53.0' }], sauce: { username: 'user', accessKey: 'key', maxConcurrent: 10 }})
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11.0' }], sauce: { username: 'user', accessKey: 'key', maxConcurrent: 10 }})
           .catch(function() {
             throw new Error('Should not be here');
           });
       });
 
       it('should allow multiple unique browsers', function() {
-        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }, { browserName: 'firefox', version: '53.0' }], sauce: { username: 'user', accessKey: 'key' }})
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }, { browserName: 'safari', version: '11.0' }], sauce: { username: 'user', accessKey: 'key' }})
           .catch(function() {
             throw new Error('Should not be here');
           });


### PR DESCRIPTION
## Changes

- Add built-in support for Firefox, without requiring Sauce Labs
- Update browser validation rules
- Update tunnel to only bind TLS
- Update README
- Update unit tests

## How to Test

```
$ npm test
```
