### PR TITLE
Add browser-specific includeRules/excludeRules

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -51,6 +51,18 @@ var displayBrowser = function(browser) {
   return result;
 };
 
+var convertRegex = function(array) {
+  return array.map(function(item) {
+    if (item instanceof RegExp) {
+      return {
+        source: item.source,
+        flags: item.flags
+      };
+    }
+    return item;
+  });
+};
+
 exports.run = function(config) {
   var timer;
   // create copy of config
@@ -117,6 +129,16 @@ exports.run = function(config) {
           console.log('Browsers:');
           config.browsers.forEach(function(browser, index) {
             console.log('  ' + (index + 1) + '. ' + displayBrowser(browser));
+          });
+          // convert RegExp into plain objects so that they can be JSON stringified
+          config.browsers = config.browsers.map(function(browser) {
+            if (browser.includeRules) {
+              browser.includeRules = convertRegex(browser.includeRules);
+            }
+            if (browser.excludeRules) {
+              browser.excludeRules = convertRegex(browser.excludeRules);
+            }
+            return browser;
           });
         }
         if (config.resolution || config.resolutions) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,6 +1,16 @@
 var Joi = require('joi');
 var Promise = require('bluebird');
 
+var includeRulesSchema = exports.includeRulesSchema = Joi.array().min(0).items(
+  Joi.string(),
+  Joi.object().type(RegExp)
+);
+
+var excludeRulesSchema = exports.excludeRulesSchema = Joi.array().min(0).items(
+  Joi.string(),
+  Joi.object().type(RegExp)
+);
+
 var resolutionSchema = exports.resolutionSchema = Joi.alternatives().try(
   Joi.string().regex(/^[0-9]{3,4}x[0-9]{3,4}$/, 'resolution'),
   Joi.object().keys({
@@ -16,11 +26,15 @@ var resolutionSchema = exports.resolutionSchema = Joi.alternatives().try(
 
 var browsersSchema = exports.browsersSchema = Joi.array().min(1).unique().items(
   Joi.object().keys({
-    browserName: Joi.string().valid(['chrome', 'firefox']).required()
+    browserName: Joi.string().valid(['chrome', 'firefox']).required(),
+    includeRules: includeRulesSchema,
+    excludeRules: excludeRulesSchema,
   }),
   Joi.object().keys({
     browserName: Joi.string().valid(['firefox', 'safari', 'microsoftedge', 'internet explorer']).required(),
-    version: Joi.string().required()
+    version: Joi.string().required(),
+    includeRules: includeRulesSchema,
+    excludeRules: excludeRulesSchema,
   })
 );
 
@@ -92,16 +106,6 @@ var stepsSchema = exports.stepsSchema = Joi.array().min(0).items(
     type: Joi.string().valid('pause').required(),
     waitTime: Joi.number().required()
   })
-);
-
-var includeRulesSchema = exports.includeRulesSchema = Joi.array().min(0).items(
-  Joi.string(),
-  Joi.object().type(RegExp)
-);
-
-var excludeRulesSchema = exports.excludeRulesSchema = Joi.array().min(0).items(
-  Joi.string(),
-  Joi.object().type(RegExp)
 );
 
 var runnerSchema = Joi.object().keys({

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -334,6 +334,20 @@ describe('screener-runner/src/validate', function() {
             throw new Error('Should not be here');
           });
       });
+
+      it('should allow browser includeRules', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }, { browserName: 'firefox' }, { browserName: 'internet explorer', version: '11', includeRules: [/^Button/] }]})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should allow browser excludeRules', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome' }, { browserName: 'firefox' }, { browserName: 'internet explorer', version: '11', excludeRules: [/^Button/] }]})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
     });
 
     describe('validate.resolutions', function() {


### PR DESCRIPTION
## Changes

- Add `includeRules` to browsersSchema
- Add `excludeRules` to browsersSchema
- convert regex rules to object before json stringifying
- Update unit tests

## How to Test

```
$ npm test
```
