### PR TITLE
Add port to tunnel host header

### DIFF
--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -7,9 +7,15 @@ exports.connect = function(host, token) {
     return Promise.reject(new Error('No Tunnel Token'));
   }
   var urlObj = url.parse('http://' + host);
+  var port = urlObj.port || 80;
+  var hostHeader = urlObj.hostname;
+  // include port in host header when not default port 80
+  if (port !== 80) {
+    hostHeader += ':' + port;
+  }
   var options = {
-    addr: urlObj.hostname + ':' + (urlObj.port || 80),
-    host_header: urlObj.hostname,
+    addr: urlObj.hostname + ':' + port,
+    host_header: hostHeader,
     bind_tls: true,
     authtoken: token
   };

--- a/test/tunnel.spec.js
+++ b/test/tunnel.spec.js
@@ -17,7 +17,7 @@ describe('screener-runner/src/tunnel', function() {
         connect: function(options, cb) {
           expect(options).to.deep.equal({
             addr: 'localhost:8080',
-            host_header: 'localhost',
+            host_header: 'localhost:8080',
             authtoken: 'token',
             bind_tls: true
           });


### PR DESCRIPTION
## Changes

- Add port number to tunnel host_header field
- Update unit tests

## How to Test

```
$ npm test
```
