### PR TITLE
Add support for Semaphore 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.11.2
+- Add handling for Semaphore 2.0, using env vars SEMAPHORE_WORKFLOW_ID,  SEMAPHORE_GIT_BRANCH, SEMAPHORE_GIT_PR_SHA.
+
 ## 0.11.1
 
 - Specify the version of Sauce Connect that is being used by screener-runner.

--- a/src/ci.js
+++ b/src/ci.js
@@ -76,9 +76,9 @@ exports.getVars = function() {
   // Semaphore
   if (env.CI === 'true' && env.SEMAPHORE === 'true') {
     return {
-      build: env.SEMAPHORE_BUILD_NUMBER,
-      branch: env.BRANCH_NAME,
-      commit: env.REVISION
+      build: env.SEMAPHORE_BUILD_NUMBER || env.SEMAPHORE_WORKFLOW_ID,
+      branch: env.BRANCH_NAME || env.SEMAPHORE_GIT_BRANCH,
+      commit: env.REVISION || env.SEMAPHORE_GIT_PR_SHA
     };
   }
   // GitLab

--- a/src/ci.js
+++ b/src/ci.js
@@ -78,7 +78,7 @@ exports.getVars = function() {
     return {
       build: env.SEMAPHORE_BUILD_NUMBER || env.SEMAPHORE_WORKFLOW_ID,
       branch: env.BRANCH_NAME || env.SEMAPHORE_GIT_BRANCH,
-      commit: env.REVISION || env.SEMAPHORE_GIT_PR_SHA
+      commit: env.REVISION || env.SEMAPHORE_GIT_PR_SHA || env.SEMAPHORE_GIT_SHA
     };
   }
   // GitLab

--- a/test/ci.spec.js
+++ b/test/ci.spec.js
@@ -185,6 +185,22 @@ describe('screener-runner/src/ci', function() {
       });
     });
 
+    it('should return build/branch from Semaphore 2.0', function() {
+      process.env = {
+        CI: 'true',
+        SEMAPHORE: 'true',
+        SEMAPHORE_GIT_BRANCH: 'semaphore2-branch',
+        SEMAPHORE_GIT_PR_SHA: 'semaphore2-commit',
+        SEMAPHORE_WORKFLOW_ID: 'semaphore2-build'
+      };
+      var result = CI.getVars();
+      expect(result).to.deep.equal({
+        build: 'semaphore2-build',
+        branch: 'semaphore2-branch',
+        commit: 'semaphore2-commit'
+      });
+    });
+
     it('should return build/branch from GitLab', function() {
       process.env = {
         CI: 'true',

--- a/test/ci.spec.js
+++ b/test/ci.spec.js
@@ -185,12 +185,12 @@ describe('screener-runner/src/ci', function() {
       });
     });
 
-    it('should return build/branch from Semaphore 2.0', function() {
+    it('should return build/branch from Semaphore 2.0 No PR', function() {
       process.env = {
         CI: 'true',
         SEMAPHORE: 'true',
         SEMAPHORE_GIT_BRANCH: 'semaphore2-branch',
-        SEMAPHORE_GIT_PR_SHA: 'semaphore2-commit',
+        SEMAPHORE_GIT_SHA: 'semaphore2-commit',
         SEMAPHORE_WORKFLOW_ID: 'semaphore2-build'
       };
       var result = CI.getVars();
@@ -198,6 +198,22 @@ describe('screener-runner/src/ci', function() {
         build: 'semaphore2-build',
         branch: 'semaphore2-branch',
         commit: 'semaphore2-commit'
+      });
+    });
+
+    it('should return build/branch from Semaphore 2.0 PR', function() {
+      process.env = {
+        CI: 'true',
+        SEMAPHORE: 'true',
+        SEMAPHORE_GIT_BRANCH: 'semaphore2-branch',
+        SEMAPHORE_GIT_PR_SHA: 'semaphore2-pr-commit',
+        SEMAPHORE_WORKFLOW_ID: 'semaphore2-build'
+      };
+      var result = CI.getVars();
+      expect(result).to.deep.equal({
+        build: 'semaphore2-build',
+        branch: 'semaphore2-branch',
+        commit: 'semaphore2-pr-commit'
       });
     });
 


### PR DESCRIPTION
The new version of Semaphore changed some of the environment variables.

Unfortunately, there's no explicit way to determine if you're using 1.0 or 2.0,
so this PR checks for the original variables first, then the 2.0 variables.

For Branch information, this PR relies on the 'Workflow ID'. This means that
Github status is updated for the same "Branch" across all pipelines in the same
Semaphore 2.0 run.  From their docs, this seems to most closely match how
Semaphore integrates with Github.  The alternative would be to use Pipeline ID.