### PR TITLE
Fix browser version validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Change Log
 
+## 0.11.3
+- Bug: Fix browser validation issue from 0.11.2
+
 ## 0.11.2
+- BREAKING BUG (fixed in 0.11.3): Browser versions are limited to major and minor versions only (e.g. `1` or `1.0.0` will fail validation).
 - Add handling for Semaphore 2.0, using env vars SEMAPHORE_WORKFLOW_ID,  SEMAPHORE_GIT_BRANCH, SEMAPHORE_GIT_PR_SHA.
 
 ## 0.11.1
-
 - Specify the version of Sauce Connect that is being used by screener-runner.
 
 ## 0.11.0
-
 - Feature: Automatically download sauce connect client with version `4.5.4`
   - Update sauce object schema to add `launchSauceConnect` flag
   - Added validation rules for new launchSauceConnect option by using joi 14.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ## 0.11.3
 - Bug: Fix browser validation issue from 0.11.2
+  - Patch versions will now pass validation, despite Sauce Labs ignoring the patch version when setting up the test browser (NOTE: patch version _will_ remain present in Screener log).
 
 ## 0.11.2
-- BREAKING BUG (fixed in 0.11.3): Browser versions are limited to major and minor versions only (e.g. `1` or `1.0.0` will fail validation).
 - Add handling for Semaphore 2.0, using env vars SEMAPHORE_WORKFLOW_ID,  SEMAPHORE_GIT_BRANCH, SEMAPHORE_GIT_PR_SHA.
 
 ## 0.11.1
 - Specify the version of Sauce Connect that is being used by screener-runner.
 
 ## 0.11.0
+- BREAKING BUG (fixed in 0.11.3): Patch browser versions (e.g. `1.1.1`) fail validation.
+  - User reported using patch versions historically, resulting in an error when updating to 0.11.0.
 - Feature: Automatically download sauce connect client with version `4.5.4`
   - Update sauce object schema to add `launchSauceConnect` flag
   - Added validation rules for new launchSauceConnect option by using joi 14.3.1

--- a/src/validate.js
+++ b/src/validate.js
@@ -41,7 +41,7 @@ var browsersSchema = exports.browsersSchema = Joi.array().min(1).unique().items(
   }),
   Joi.object().keys({
     browserName: Joi.string().valid('chrome', 'firefox', 'safari', 'microsoftedge', 'internet explorer').required(),
-    version: Joi.string().regex(/^(\d+)(\.\d+)?(\.\d+)?$/).required(),
+    version: Joi.string().regex(/^(\d+\.\d+)(\.\d+)?$/).required(),
     includeRules: includeRulesSchema,
     excludeRules: excludeRulesSchema
   })

--- a/src/validate.js
+++ b/src/validate.js
@@ -41,7 +41,7 @@ var browsersSchema = exports.browsersSchema = Joi.array().min(1).unique().items(
   }),
   Joi.object().keys({
     browserName: Joi.string().valid('chrome', 'firefox', 'safari', 'microsoftedge', 'internet explorer').required(),
-    version: Joi.string().regex(/^\d+\.\d+$/).required(),
+    version: Joi.string().regex(/^(\d+)(\.\d+)?(\.\d+)?$/).required(),
     includeRules: includeRulesSchema,
     excludeRules: excludeRulesSchema
   })

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -387,9 +387,9 @@ describe('screener-runner/src/validate', function() {
       });
 
       it('should error when browser has a major version', function(done) {
-        Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11' }])
+        Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11' }]})
           .catch(function(err) {
-            expect(err.message).to.equal('"value" at position 0 does not match any of the allowed types');
+            expect(err.message).to.equal('child "browsers" fails because ["browsers" at position 0 does not match any of the allowed types]');
             done();
           });
       });

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -386,7 +386,7 @@ describe('screener-runner/src/validate', function() {
           });
       });
 
-      it('should error when browser is a major version', function(done) {
+      it('should error when browser has a major version', function(done) {
         Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11' }])
           .catch(function(err) {
             expect(err.message).to.equal('"value" at position 0 does not match any of the allowed types');

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -379,8 +379,23 @@ describe('screener-runner/src/validate', function() {
           });
       });
 
-      it('should allow browsers to have any subset of a semver version', function() {
-        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome', version: '70.0.1' }, { browserName: 'firefox', version: '57.0' }, { browserName: 'microsoftedge', version: '17' }]})
+      it('should allow browsers to have minor and patch versions', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome', version: '70.0.1' }, { browserName: 'firefox', version: '57.0' }]})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
+      it('should error when browser is a major version', function(done) {
+        Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11' }])
+          .catch(function(err) {
+            expect(err.message).to.equal('"value" at position 0 does not match any of the allowed types');
+            done();
+          });
+      });
+
+      it('should allow internet explorer browser to have major version 11', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'internet explorer', version: '11' }]})
           .catch(function() {
             throw new Error('Should not be here');
           });

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -379,6 +379,13 @@ describe('screener-runner/src/validate', function() {
           });
       });
 
+      it('should allow browsers to have any subset of a semver version', function() {
+        return Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'chrome', version: '70.0.1' }, { browserName: 'firefox', version: '57.0' }, { browserName: 'microsoftedge', version: '17' }]})
+          .catch(function() {
+            throw new Error('Should not be here');
+          });
+      });
+
       it('should error when both sauce and browserStack options are present', function(done) {
         Validate.runnerConfig({apiKey: 'key', projectRepo: 'repo', states: [], browsers: [{ browserName: 'safari', version: '11.0' }], sauce: { username: 'user', accessKey: 'key' }, browserStack: { username: 'user', accessKey: 'key' }})
           .catch(function(err) {


### PR DESCRIPTION
### Bug
Latest browser version validation changes will fail for anything other than `X.X`, but historically `X` and `X.X.X` were supported as well.

### Fix
This reverts the restriction, while maintaining validation of a subset of semver.

### Implementation
* The `?` regex will make the preceding group (in parens `()`) optional.
* We don't need to update the regex where `launchSauceConnect` is true, because Sauce only supports `X.X`.