### PR TITLE
Increase ngrok retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.11.6
+- Increase retries/timeout for Ngrok
+
 ## 0.11.5
 - Update dependency http-proxy to 1.18.1
 

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -67,7 +67,7 @@ exports.connect = function({ ngrok, sauce }, tries = 0) {
         return urlObj.host;
       })
       .catch(ex => {
-        if (tries < 2) {
+        if (tries < 30) {
           // on error, wait and retry
           return Promise.delay(1000).then(() =>
             exports.connect({ ngrok }, tries + 1)

--- a/test/tunnel.spec.js
+++ b/test/tunnel.spec.js
@@ -4,7 +4,7 @@ var sinon = require('sinon');
 var Tunnel = rewire('../src/tunnel');
 
 describe('screener-runner/src/tunnel', function() {
-  this.timeout(5000);
+  this.timeout(35000);
 
   describe('Tunnel.connect', function() {
     it('should error when no token', function(done) {


### PR DESCRIPTION
## Changes

- Increase Ngrok retries/timeout to 30s to help resolve intermittent error "ngrok is not yet ready to start tunnels"

## How to Test

```
$ npm test
```
