### PR TITLE
Bump saucelabs from 7.0.4 to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "portfinder": "~1.0.10",
     "request": "~2.87.0",
     "requestretry": "~2.0.2",
-    "saucelabs": "~7.0.4",
+    "saucelabs": "~7.2.0",
     "screener-ngrok": "2.2.30",
     "shortid": "~2.2.15"
   },


### PR DESCRIPTION
saucelabs v7.0.4 pulls semver-regex 2.0.0 transitively and semver-regex@2.0.0 has security vulnerability. With saucelabs@7.2.0 this issue is resolved.